### PR TITLE
Fixes merge panel selection for 'medulla7column'.

### DIFF
--- a/src/Annotation/MergePanel.jsx
+++ b/src/Annotation/MergePanel.jsx
@@ -153,11 +153,9 @@ function onKeyPressMerge(event, mergeManager) {
 
 // Neuroglancer's notion of "visible" corresponds to other applications' notion of "selected".
 function onVisibleChangedMerge(segments, layer, mergeManager) {
-  if (layer.name.toLowerCase().includes('segmentation')) {
-    const selectionStrings = segments.toJSON();
-    const selectionNow = selectionStrings.map((s) => parseInt(s, 10));
-    mergeManager.select(selectionNow);
-  }
+  const selectionStrings = segments.toJSON();
+  const selectionNow = selectionStrings.map((s) => parseInt(s, 10));
+  mergeManager.select(selectionNow);
 }
 
 export { MergePanel, onKeyPressMerge, onVisibleChangedMerge };


### PR DESCRIPTION
In the "medulla7column" dataset, the segmentation layer is named "reconstruction", so the code should not assume that it is named "segmentation".  Without this fix, the merging functionality never tries to keep track of bodies to be merged.