### PR TITLE
Now recognizes per-dataset write permissions in addition to global

### DIFF
--- a/src/Atlas.jsx
+++ b/src/Atlas.jsx
@@ -12,6 +12,7 @@ import DatasetFilter from './Atlas/DatasetFilter';
 import FilterType from './Atlas/FilterType';
 import VerifyType from './Atlas/VerifyType';
 import { addAlert } from './actions/alerts';
+import { canWrite } from './utils/permissions';
 
 const useStyles = makeStyles({
   window: {
@@ -306,7 +307,8 @@ export default function Atlas(props) {
   };
 
   // user has clio write
-  const allowedToVerifyAnnotaton = roles.global_roles && roles.global_roles.includes('clio_write');
+  const allowedToVerifyAnnotaton = selectedAnnotation
+                                   && canWrite(roles, selectedAnnotation.dataset);
   const alreadyVerified = selectedAnnotation && selectedAnnotation.verified;
 
 

--- a/src/utils/permissions.jsx
+++ b/src/utils/permissions.jsx
@@ -1,0 +1,12 @@
+/* eslint-disable-next-line  import/prefer-default-export */
+export function canWrite(roles, dataset) {
+  // Check global roles
+  if (roles.global_roles && roles.global_roles.includes('clio_write')) {
+    return true;
+  }
+  // Check dataset roles
+  if (Object.keys(roles.datasets).includes(dataset) && roles.datasets[dataset].includes('clio_write')) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Now recognizes per-dataset write permissions in addition to global. Modified Atlas.jsx and added utils/permissions.jsx.