### PR TITLE
To support uploading local annoations from ng urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.4.3",
-    "@janelia-flyem/react-neuroglancer": "^1.12.0",
+    "@janelia-flyem/react-neuroglancer": "^1.13.0",
     "@material-ui/core": "^4.9.10",
     "@material-ui/icons": "^4.0.0-beta.0",
     "@material-ui/lab": "^4.0.0-alpha.57",


### PR DESCRIPTION
This PR makes the clio annotation table be able to extract annotations from neuroglancer URLs and upload them. It needs the latest react-neuroglancer update to work.