### PR TITLE
Hide skeletons in the segmentation layer by default

### DIFF
--- a/src/Annotate.jsx
+++ b/src/Annotate.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { useSelector, shallowEqual } from 'react-redux';
 import { getNeuroglancerColor } from '@janelia-flyem/react-neuroglancer';
 import activeElementNeedsKeypress from './utils/events';
+import { addLayersFromDataset } from './utils/neuroglancer';
 import AnnotationPanel from './Annotation/AnnotationPanel';
 import {
   ANNOTATION_COLUMNS, ATLAS_COLUMNS, ANNOTATION_SHADER, ATLAS_SHADER,
@@ -75,16 +76,6 @@ const useStyles = makeStyles((theme) => {
   });
 });
 
-const inferredLayerType = (layer) => {
-  if (layer.name.includes('segmentation')) {
-    return 'segmentation';
-  }
-  if (layer.location.includes('segmentation')) {
-    return 'segmentation';
-  }
-  return undefined;
-};
-
 // eslint-disable-next-line object-curly-newline
 export default function Annotate({ children, actions, datasets, selectedDatasetName }) {
   const user = useSelector((state) => state.user.get('googleUser'), shallowEqual);
@@ -127,21 +118,7 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
         },
       ];
 
-      if ('layers' in dataset) {
-        dataset.layers.forEach((layer) => {
-          let layerUrl = layer.location;
-          if (!layer.location.match(/^dvid/)) {
-            layerUrl = `precomputed://${layer.location}`;
-          }
-          layers.push({
-            name: layer.name,
-            type: layer.type || inferredLayerType(layer),
-            source: {
-              url: layerUrl,
-            },
-          });
-        });
-      }
+      addLayersFromDataset(layers, dataset, true);
 
       const viewerOptions = {
         position: [],

--- a/src/Annotate.jsx
+++ b/src/Annotate.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { useSelector, shallowEqual } from 'react-redux';
 import { getNeuroglancerColor } from '@janelia-flyem/react-neuroglancer';
 import activeElementNeedsKeypress from './utils/events';
-import { addLayersFromDataset } from './utils/neuroglancer';
+import { makeLayersFromDataset } from './utils/neuroglancer';
 import AnnotationPanel from './Annotation/AnnotationPanel';
 import {
   ANNOTATION_COLUMNS, ATLAS_COLUMNS, ANNOTATION_SHADER, ATLAS_SHADER,
@@ -116,9 +116,8 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
           shader: ATLAS_SHADER,
           tool: 'annotatePoint',
         },
+        ...makeLayersFromDataset(dataset, true),
       ];
-
-      addLayersFromDataset(layers, dataset, true);
 
       const viewerOptions = {
         position: [],

--- a/src/Annotation/AnnotationPanel.jsx
+++ b/src/Annotation/AnnotationPanel.jsx
@@ -35,6 +35,8 @@ export default function AnnotationPanel(props) {
     const index = parseInt(newValue, 10);
     if (config.layers[index]) {
       actions.selectViewerLayer(config.layers[index].name);
+    } else {
+      actions.selectViewerLayer('');
     }
   };
 

--- a/src/Annotation/AnnotationTable.jsx
+++ b/src/Annotation/AnnotationTable.jsx
@@ -169,6 +169,7 @@ function AnnotationTable(props) {
     if (data.rows.length === 0) {
       updateTableRows();
     }
+    return updateTableRows.cancel;
   }, [
     data,
     updateTableRows,

--- a/src/Atlas.jsx
+++ b/src/Atlas.jsx
@@ -13,7 +13,7 @@ import FilterType from './Atlas/FilterType';
 import VerifyType from './Atlas/VerifyType';
 import { addAlert } from './actions/alerts';
 import { canWrite } from './utils/permissions';
-import { addLayersFromDataset } from './utils/neuroglancer';
+import { makeLayersFromDataset } from './utils/neuroglancer';
 
 const useStyles = makeStyles({
   window: {
@@ -119,9 +119,8 @@ export default function Atlas(props) {
             url: `clio://${projectUrl}/${selectedDataset.name}?auth=neurohub&kind=atlas`,
           },
         },
+        ...makeLayersFromDataset(selectedDataset, false),
       ];
-
-      addLayersFromDataset(layers, selectedDataset, false);
 
       const viewerOptions = {
         position: selectedAnnotation.location,

--- a/src/Atlas.jsx
+++ b/src/Atlas.jsx
@@ -13,6 +13,7 @@ import FilterType from './Atlas/FilterType';
 import VerifyType from './Atlas/VerifyType';
 import { addAlert } from './actions/alerts';
 import { canWrite } from './utils/permissions';
+import { addLayersFromDataset } from './utils/neuroglancer';
 
 const useStyles = makeStyles({
   window: {
@@ -120,22 +121,7 @@ export default function Atlas(props) {
         },
       ];
 
-      if ('layers' in selectedDataset) {
-        selectedDataset.layers.forEach((layer) => {
-          let layerUrl = layer.location;
-          if (!layer.location.match(/^dvid/)) {
-            layerUrl = `precomputed://${layer.location}`;
-          }
-
-          layers.push({
-            name: layer.name,
-            type: layer.type,
-            source: {
-              url: layerUrl,
-            },
-          });
-        });
-      }
+      addLayersFromDataset(layers, selectedDataset, false);
 
       const viewerOptions = {
         position: selectedAnnotation.location,

--- a/src/ImageSearch/NGLoader.jsx
+++ b/src/ImageSearch/NGLoader.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
+import { addLayersFromDataset } from '../utils/neuroglancer';
 
 const useStyles = makeStyles({
   window: {
@@ -43,21 +44,7 @@ export default function NGLoader({
         },
       ];
 
-      if ('layers' in dataset) {
-        dataset.layers.forEach((layer) => {
-          let layerUrl = layer.location;
-          if (!layer.location.match(/^dvid/)) {
-            layerUrl = `precomputed://${layer.location}`;
-          }
-          layers.push({
-            name: layer.name,
-            type: layer.type,
-            source: {
-              url: layerUrl,
-            },
-          });
-        });
-      }
+      addLayersFromDataset(layers, dataset, false);
 
       const viewerOptions = {
         position: coords,

--- a/src/ImageSearch/NGLoader.jsx
+++ b/src/ImageSearch/NGLoader.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
-import { addLayersFromDataset } from '../utils/neuroglancer';
+import { makeLayersFromDataset } from '../utils/neuroglancer';
 
 const useStyles = makeStyles({
   window: {
@@ -42,9 +42,8 @@ export default function NGLoader({
             url: `clio://${projectUrl}/${dataset.name}?auth=neurohub`,
           },
         },
+        ...makeLayersFromDataset(dataset, false),
       ];
-
-      addLayersFromDataset(layers, dataset, false);
 
       const viewerOptions = {
         position: coords,

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -13,5 +13,10 @@ export default (func, wait, immediate) => {
     timeout = setTimeout(later, wait);
     if (callNow) func.apply(context, args);
   }
+
+  Object.assign(debounced, {
+    cancel() { clearTimeout(timeout); },
+  });
+
   return debounced;
 };

--- a/src/utils/neuroglancer.js
+++ b/src/utils/neuroglancer.js
@@ -10,9 +10,9 @@ function inferredLayerType(layer) {
 }
 
 /* eslint-disable-next-line  import/prefer-default-export */
-export function addLayersFromDataset(layers, dataset, inferringType) {
+export function makeLayersFromDataset(dataset, inferringType) {
   if ('layers' in dataset) {
-    dataset.layers.forEach((layer) => {
+    return dataset.layers.map((layer) => {
       let layerUrl = layer.location;
       if (!layer.location.match(/^dvid/)) {
         layerUrl = `precomputed://${layer.location}`;
@@ -40,7 +40,9 @@ export function addLayersFromDataset(layers, dataset, inferringType) {
         layerConfig.source.enableDefaultSubsources = false;
       }
 
-      layers.push(layerConfig);
+      return layerConfig;
     });
   }
+
+  return [];
 }


### PR DESCRIPTION
This PR is mainly for turning off skeleton display by default in the 'Annotate' workspace. While implementing this function, I refactored the layer creation part to remove duplicate code. This PR also includes a minor fix for canceling scheduled annotation table update when the annotation panel is unmounted.