### PR TITLE
A better way to turn off skeletons by default

### DIFF
--- a/src/utils/neuroglancer.js
+++ b/src/utils/neuroglancer.js
@@ -33,11 +33,9 @@ export function makeLayersFromDataset(dataset, inferringType) {
 
       if (type === 'segmentation') {
         layerConfig.source.subsources = {
-          default: true,
-          meshes: true,
-          bounds: true,
+          skeletons: false,
         };
-        layerConfig.source.enableDefaultSubsources = false;
+        layerConfig.source.enableDefaultSubsources = true;
       }
 
       return layerConfig;


### PR DESCRIPTION
The previous implementation can turn off some other subsources unexpectedly.