### PR TITLE
Fixes annotation panel update

### DIFF
--- a/src/Annotate.jsx
+++ b/src/Annotate.jsx
@@ -225,6 +225,7 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
 
     const annotationConfig = {
       width: `${SIDEBAR_WIDTH_PX}px`,
+      datasetName: dataset.name,
       layers: [
         {
           name: 'annotations',
@@ -237,6 +238,7 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
             token: user.getAuthResponse().id_token,
           },
           setSelectionChangedCallback,
+          dataSource: dataset.name,
         },
         {
           name: 'atlas',
@@ -249,6 +251,7 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
             token: user.getAuthResponse().id_token,
           },
           setSelectionChangedCallback,
+          dataSource: dataset.name,
         },
       ],
     };

--- a/src/Annotation/AnnotationPanel.jsx
+++ b/src/Annotation/AnnotationPanel.jsx
@@ -40,6 +40,10 @@ export default function AnnotationPanel(props) {
     }
   };
 
+  React.useEffect(() => {
+    setTabValue('0');
+  }, [config.datasetName]);
+
   const numTabs = config.layers.length + (children ? children.length : 0);
   const totalWidth = config.width.replace(/\D/g, '');
   const tabWidth = Math.max(totalWidth / numTabs, 100);
@@ -56,6 +60,7 @@ export default function AnnotationPanel(props) {
         layerName={layer.name}
         locateItem={layer.locateItem}
         setSelectionChangedCallback={layer.setSelectionChangedCallback}
+        dataSource={layer.dataSource}
         actions={actions}
       />
     </TabPanel>
@@ -92,9 +97,11 @@ export default function AnnotationPanel(props) {
 
 AnnotationPanel.propTypes = {
   config: PropTypes.shape({
+    datasetName: PropTypes.string.isRequired,
     layers: PropTypes.arrayOf(PropTypes.shape({
       dataConfig: PropTypes.object,
       name: PropTypes.string,
+      dataSource: PropTypes.string,
     })),
     width: PropTypes.string,
   }).isRequired,

--- a/src/Annotation/AnnotationTable.jsx
+++ b/src/Annotation/AnnotationTable.jsx
@@ -29,7 +29,7 @@ import debounce from '../utils/debounce';
 
 function AnnotationTable(props) {
   const {
-    layerName, dataConfig, actions, tools, setSelectionChangedCallback,
+    layerName, dataConfig, actions, tools, setSelectionChangedCallback, dataSource,
   } = props;
   const [data, setData] = React.useState({});
   const [selectedAnnotation, setSelectedAnnotation] = React.useState(null);
@@ -178,6 +178,10 @@ function AnnotationTable(props) {
   ]);
 
   useEffect(() => {
+    setData({});
+  }, [dataSource]);
+
+  useEffect(() => {
     const configureAnnotationLayerFunc = (layer) => configureAnnotationLayerChanged(layer, {
       onAnnotationAdded,
       onAnnotationDeleted,
@@ -249,8 +253,9 @@ function AnnotationTable(props) {
 AnnotationTable.propTypes = {
   layerName: PropTypes.string.isRequired,
   dataConfig: PropTypes.object.isRequired,
-  tools: PropTypes.arrayOf(PropTypes.object),
+  dataSource: PropTypes.string.isRequired,
   actions: PropTypes.object.isRequired,
+  tools: PropTypes.arrayOf(PropTypes.object),
   setSelectionChangedCallback: PropTypes.func,
 };
 

--- a/src/Annotation/AnnotationTable.jsx
+++ b/src/Annotation/AnnotationTable.jsx
@@ -31,7 +31,7 @@ function AnnotationTable(props) {
   const {
     layerName, dataConfig, actions, tools, setSelectionChangedCallback,
   } = props;
-  const [data, setData] = React.useState({ rows: [] });
+  const [data, setData] = React.useState({});
   const [selectedAnnotation, setSelectedAnnotation] = React.useState(null);
 
   const annotationToItem = React.useCallback(
@@ -107,7 +107,9 @@ function AnnotationTable(props) {
       });
       setData({ rows: newData.sort((r1, r2) => r2.timestamp - r1.timestamp) });
 
-      setSelectedAnnotation(getSelectedAnnotationId(undefined, layerName));
+      if (newData.length > 0) {
+        setSelectedAnnotation(getSelectedAnnotationId(undefined, layerName));
+      }
       /*
       const layer = getAnnotationLayer(undefined, layerName);
       if (layer.selectedAnnotation && layer.selectedAnnotation.value) {
@@ -166,7 +168,7 @@ function AnnotationTable(props) {
   }
 
   useEffect(() => {
-    if (data.rows.length === 0) {
+    if (data.rows === undefined) { // For remount initialization
       updateTableRows();
     }
     return updateTableRows.cancel;
@@ -231,7 +233,7 @@ function AnnotationTable(props) {
   return (
     <div>
       <DataTable
-        data={data}
+        data={{ rows: data.rows || [] }}
         selectedId={selectedAnnotation}
         config={dataConfig}
         getId={React.useCallback((row) => row.id, [])}


### PR DESCRIPTION
This PR has the following changes:

1. Setting the tab back to 'annotation' when switching to a new dataset, and updating the annotation table if necessary.
2. Fixing annotation table initialization to prevent unnecessary table updates that may hurt performance.
