### PR TITLE
Resets view center in image search after a dataset change

### DIFF
--- a/src/ImageSearch.jsx
+++ b/src/ImageSearch.jsx
@@ -60,6 +60,10 @@ export default function ImageSearch({ actions, datasets, selectedDatasetName, ch
 
   const updatedActions = { ...actions, setMousePosition };
 
+  React.useEffect(() => {
+    setMousePosition([]);
+  }, [selectedDatasetName]);
+
   const handleChange = (event) => {
     // make sure the mouse position gets cleared out so that we don't
     // try to load the data at that point when switching pick modes


### PR DESCRIPTION
This PR is for fixing the problem that the image center stays at the same place, which can be out of range for some datasets, when switching between datasets in image search. The solution used selectedDatasetName to trigger clearing out mouse position. I'm not sure if there is a better solution though.