### PR TITLE
Disables edit buttons for verified annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "dependencies": {
         "@babel/core": "7.4.3",
-        "@janelia-flyem/react-neuroglancer": "^2.0.1",
+        "@janelia-flyem/react-neuroglancer": "^2.0.3",
         "@material-ui/core": "^4.9.10",
         "@material-ui/icons": "^4.0.0-beta.0",
         "@material-ui/lab": "^4.0.0-alpha.57",
@@ -1141,9 +1141,9 @@
       }
     },
     "node_modules/@janelia-flyem/neuroglancer": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/@janelia-flyem/neuroglancer/-/neuroglancer-2.20.3.tgz",
-      "integrity": "sha512-0vuqhrSxjHtPYTFOZD5kKYT+wrXESqGnTG7OAI2mQTuPMzLkyA1r1jGH4w0QhQwHajlpgRqgSb7UHfWUayAz6w==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@janelia-flyem/neuroglancer/-/neuroglancer-2.21.0.tgz",
+      "integrity": "sha512-LzNBHsODirgBzRSqd1fg0M3KE8el5zjaQYywmxI3g6lmk8KboNNufAaF31T63m3+TmSjb51s9RRmVNddbOEAfQ==",
       "dependencies": {
         "@types/codemirror": "0.0.98",
         "@types/gl-matrix": "^2.4.5",
@@ -1214,11 +1214,11 @@
       }
     },
     "node_modules/@janelia-flyem/react-neuroglancer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@janelia-flyem/react-neuroglancer/-/react-neuroglancer-2.0.1.tgz",
-      "integrity": "sha512-DyitCVCG6BuU90rdPW2uIE9c5j3XrT40xdLHm5rUNZCsjPVzDNxcVYRa9cGdqc1auxw99ZIZ0hBFkqnbDdkB5Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@janelia-flyem/react-neuroglancer/-/react-neuroglancer-2.0.3.tgz",
+      "integrity": "sha512-FrE5YpXqW2LdHdpjxo51zQmLPcK6sq3z2z7FBpjoQCIOOzrVYkeoPJIc4VolOTlc44IK+FMrsCei1bZlRBvIFA==",
       "dependencies": {
-        "@janelia-flyem/neuroglancer": "^2.20.3"
+        "@janelia-flyem/neuroglancer": "^2.21.0"
       },
       "peerDependencies": {
         "prop-types": "^15.6.2",
@@ -6100,9 +6100,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.8.54",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.54.tgz",
-      "integrity": "sha512-DJH38OiTgXJxFb/EhHrCrY8eGmtdkTtWymHpN9IYN9AF+4jykT0dQArr7wzFejpVbaB0TMIq2+vfNRWr3LXpvw==",
+      "version": "0.8.57",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.57.tgz",
+      "integrity": "sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -18891,6 +18891,7 @@
       "version": "0.1.31",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
       "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
       "engines": {
         "node": ">=0.1"
       }
@@ -19982,9 +19983,9 @@
       }
     },
     "@janelia-flyem/neuroglancer": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/@janelia-flyem/neuroglancer/-/neuroglancer-2.20.3.tgz",
-      "integrity": "sha512-0vuqhrSxjHtPYTFOZD5kKYT+wrXESqGnTG7OAI2mQTuPMzLkyA1r1jGH4w0QhQwHajlpgRqgSb7UHfWUayAz6w==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@janelia-flyem/neuroglancer/-/neuroglancer-2.21.0.tgz",
+      "integrity": "sha512-LzNBHsODirgBzRSqd1fg0M3KE8el5zjaQYywmxI3g6lmk8KboNNufAaF31T63m3+TmSjb51s9RRmVNddbOEAfQ==",
       "requires": {
         "@types/codemirror": "0.0.98",
         "@types/gl-matrix": "^2.4.5",
@@ -20047,11 +20048,11 @@
       }
     },
     "@janelia-flyem/react-neuroglancer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@janelia-flyem/react-neuroglancer/-/react-neuroglancer-2.0.1.tgz",
-      "integrity": "sha512-DyitCVCG6BuU90rdPW2uIE9c5j3XrT40xdLHm5rUNZCsjPVzDNxcVYRa9cGdqc1auxw99ZIZ0hBFkqnbDdkB5Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@janelia-flyem/react-neuroglancer/-/react-neuroglancer-2.0.3.tgz",
+      "integrity": "sha512-FrE5YpXqW2LdHdpjxo51zQmLPcK6sq3z2z7FBpjoQCIOOzrVYkeoPJIc4VolOTlc44IK+FMrsCei1bZlRBvIFA==",
       "requires": {
-        "@janelia-flyem/neuroglancer": "^2.20.3"
+        "@janelia-flyem/neuroglancer": "^2.21.0"
       }
     },
     "@jest/console": {
@@ -24135,9 +24136,9 @@
       }
     },
     "esbuild": {
-      "version": "0.8.54",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.54.tgz",
-      "integrity": "sha512-DJH38OiTgXJxFb/EhHrCrY8eGmtdkTtWymHpN9IYN9AF+4jykT0dQArr7wzFejpVbaB0TMIq2+vfNRWr3LXpvw=="
+      "version": "0.8.57",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.57.tgz",
+      "integrity": "sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA=="
     },
     "escape-html": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.4.3",
-    "@janelia-flyem/react-neuroglancer": "^2.0.1",
+    "@janelia-flyem/react-neuroglancer": "^2.0.3",
     "@material-ui/core": "^4.9.10",
     "@material-ui/icons": "^4.0.0-beta.0",
     "@material-ui/lab": "^4.0.0-alpha.57",

--- a/src/Annotation/AnnotationUtils.js
+++ b/src/Annotation/AnnotationUtils.js
@@ -219,7 +219,11 @@ export function getRowItemFromAnnotation(annotation, config) {
         locate(layerName, id, pos);
       },
     };
-    if (!annotation.verified) {
+    let { verified } = annotation;
+    if (verified === undefined) {
+      verified = annotation.ext ? annotation.ext.verified : false;
+    }
+    if (!verified) {
       item.deleteAction = () => {
         const source = getAnnotationSource(undefined, layerName);
         // console.log(source);


### PR DESCRIPTION
This fixes the broken function that disables editing for verified annotations. It requires the most recent neuroglancer update (https://github.com/neuroglancerhub/neuroglancer/commits/feature-flyem-newbuild) to work.