### PR TITLE
Fixes a syncing problem in annotation table

### DIFF
--- a/src/Annotation/AnnotationTable.jsx
+++ b/src/Annotation/AnnotationTable.jsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 
 import {
+  closeSelectionTab,
   getAnnotationSource,
   getAnnotationSelectionHost,
   configureAnnotationLayerChanged,
@@ -46,6 +47,8 @@ function AnnotationTable(props) {
   }, shallowEqual);
 
   const setSelectedGroups = React.useCallback((groups) => {
+    // Need to clear selection to avoid incorrect deref
+    closeSelectionTab();
     actions.setViewerLayerSource({
       layerName,
       source: (s) => ({ url: getAnnotationUrlWithGroups(s.url || s, groups) }),


### PR DESCRIPTION
It's a minor fix for the annotation table and requires the latest neuroglancer update (feature-flyem-newbuild) to work. The neuroglancer update also contains a fix for the token expiring problem.