### PR TITLE
Fixes 'all' option for rowsperpage in data table

### DIFF
--- a/src/Annotation/DataTable/DataTable.jsx
+++ b/src/Annotation/DataTable/DataTable.jsx
@@ -114,10 +114,10 @@ export default function DataTable(props) {
             makeRow={makeHeaderRow}
           />
           <TableBody>
-            {filteredRows.slice(
+            {(rowsPerPage > 0 ? filteredRows.slice(
               actualPage * rowsPerPage,
               actualPage * rowsPerPage + rowsPerPage,
-            ).map(
+            ) : filteredRows).map(
               (row) => (
                 <DataTableRow
                   key={getId(row)}


### PR DESCRIPTION
This PR fixes the bug that causes a data table to become empty when the 'all' option is selected for rows per page.

Please release it together with the latest Neuroglancer update, which has the new function of updating missing meshes automatically .