### PR TITLE
Removes undefined selections in synced ng state.

### DIFF
--- a/src/reducers/viewer.js
+++ b/src/reducers/viewer.js
@@ -71,6 +71,17 @@ const syncedState = (state) => {
       ngState.crossSectionScale = state.getIn(['ngState', 'crossSectionScale']);
     }
 
+    // Clear up undefined layer selection to make sure that the state is valid for Neuroglancer.
+    // This problem is caused by the way of handling states in Neuroglancer.
+    // The state JSON obtained from Neuroglancer may be rejected by Neuroglancer itself.
+    if (ngState.selection && ngState.selection.layers) {
+      Object.keys(ngState.selection.layers).forEach((layerName) => {
+        if (ngState.selection.layers[layerName] === undefined) {
+          delete ngState.selection.layers[layerName];
+        }
+      });
+    }
+
     return state.set('ngState', ngState);
   }
   return state;


### PR DESCRIPTION
Neuroglancer json encoding adds an undefined value for a layer in the selection object if nothing is selected in the layer. Passing this back to neuroglancer to restore its state can cause crash. This PR fixes the problem.