### PR TITLE
Uses layer info from clio server to improve UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.4",
       "dependencies": {
         "@babel/core": "7.4.3",
-        "@janelia-flyem/react-neuroglancer": "^2.0.3",
+        "@janelia-flyem/react-neuroglancer": "^2.2.2",
         "@material-ui/core": "^4.9.10",
         "@material-ui/icons": "^4.0.0-beta.0",
         "@material-ui/lab": "^4.0.0-alpha.57",
@@ -1141,9 +1141,9 @@
       }
     },
     "node_modules/@janelia-flyem/neuroglancer": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@janelia-flyem/neuroglancer/-/neuroglancer-2.21.0.tgz",
-      "integrity": "sha512-LzNBHsODirgBzRSqd1fg0M3KE8el5zjaQYywmxI3g6lmk8KboNNufAaF31T63m3+TmSjb51s9RRmVNddbOEAfQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@janelia-flyem/neuroglancer/-/neuroglancer-2.24.0.tgz",
+      "integrity": "sha512-5nuFOqgjMzpt9bwibcXs1+5pVjR4sQGKeiIwQgxqaW8WV78HlwXyaxO7jsMit3AJf2lakooZyD0BKcsDUR268A==",
       "dependencies": {
         "@types/codemirror": "0.0.98",
         "@types/gl-matrix": "^2.4.5",
@@ -1189,16 +1189,16 @@
       "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw=="
     },
     "node_modules/@janelia-flyem/neuroglancer/node_modules/sockjs-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
-      "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.1.tgz",
+      "integrity": "sha512-VnVAb663fosipI/m6pqRXakEOw7nvd7TUgdr3PlR/8V2I95QIdwT8L4nMxhyU8SmDBHYXU1TOElaKOmKLfYzeQ==",
       "dependencies": {
         "debug": "^3.2.6",
         "eventsource": "^1.0.7",
         "faye-websocket": "^0.11.3",
         "inherits": "^2.0.4",
         "json3": "^3.3.3",
-        "url-parse": "^1.4.7"
+        "url-parse": "^1.5.1"
       }
     },
     "node_modules/@janelia-flyem/neuroglancer/node_modules/typescript": {
@@ -1214,11 +1214,11 @@
       }
     },
     "node_modules/@janelia-flyem/react-neuroglancer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@janelia-flyem/react-neuroglancer/-/react-neuroglancer-2.0.3.tgz",
-      "integrity": "sha512-FrE5YpXqW2LdHdpjxo51zQmLPcK6sq3z2z7FBpjoQCIOOzrVYkeoPJIc4VolOTlc44IK+FMrsCei1bZlRBvIFA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@janelia-flyem/react-neuroglancer/-/react-neuroglancer-2.2.2.tgz",
+      "integrity": "sha512-m9Cw2pyc7C+F5SAMgYPubj+mnky7LL6O6wFoZfthQsJcntbO4S9tWYroiLIcx6czIvFO58HZFaGTVkRHSWztEw==",
       "dependencies": {
-        "@janelia-flyem/neuroglancer": "^2.21.0"
+        "@janelia-flyem/neuroglancer": "^2.24.0"
       },
       "peerDependencies": {
         "prop-types": "^15.6.2",
@@ -1839,9 +1839,9 @@
       "dev": true
     },
     "node_modules/@types/estree": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg=="
     },
     "node_modules/@types/gl-matrix": {
       "version": "2.4.5",
@@ -3720,7 +3720,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -3820,16 +3819,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -3839,16 +3834,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -3859,16 +3850,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -3879,16 +3866,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -3898,32 +3881,24 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -3933,8 +3908,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -3944,16 +3917,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "inBundle": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -3966,8 +3935,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -3977,16 +3944,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4003,8 +3966,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/glob": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4022,16 +3983,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4044,8 +4001,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4055,8 +4010,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4067,16 +4020,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4086,8 +4035,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4100,16 +4047,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4122,16 +4065,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/minipass": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4142,8 +4081,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/minizlib": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4153,8 +4090,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4167,16 +4102,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/ms": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/needle": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-      "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4194,8 +4125,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-      "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -4217,8 +4146,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4232,16 +4159,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4252,8 +4175,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4266,8 +4187,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4277,8 +4196,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4288,8 +4205,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4299,8 +4214,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4310,8 +4223,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4321,8 +4232,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4333,8 +4242,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4344,16 +4251,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
@@ -4369,16 +4272,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4394,8 +4293,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/rimraf": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4408,32 +4305,24 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/semver": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4443,24 +4332,18 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4470,8 +4353,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4486,8 +4367,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4500,8 +4379,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4511,8 +4388,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/tar": {
       "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4531,16 +4406,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -4550,16 +4421,12 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/yallist": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
@@ -4731,9 +4598,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.59.4",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.4.tgz",
-      "integrity": "sha512-achw5JBgx8QPcACDDn+EUUXmCYzx/zxEtOGXyjvLEvYY8GleUrnfm5D+Zb+UjShHggXKDT9AXrbkBZX6a0YSQg=="
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.60.0.tgz",
+      "integrity": "sha512-AEL7LhFOlxPlCL8IdTcJDblJm8yrAGib7I+DErJPdZd4l6imx8IMgKK3RblVgBQqz3TZJR4oknQ03bz+uNjBYA=="
     },
     "node_modules/collection-visit": {
       "version": "1.0.0",
@@ -5926,6 +5793,9 @@
         "lru-cache": "^4.1.5",
         "semver": "^5.6.0",
         "sigmund": "^1.0.1"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
       }
     },
     "node_modules/editorconfig/node_modules/lru-cache": {
@@ -6126,8 +5996,7 @@
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -9747,7 +9616,6 @@
         "@jest/types": "^24.8.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.4.0",
@@ -9850,16 +9718,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -9869,16 +9733,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -9889,16 +9749,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -9909,16 +9765,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -9928,32 +9780,24 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -9963,8 +9807,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -9974,16 +9816,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "inBundle": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -9996,8 +9834,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10007,16 +9843,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10033,8 +9865,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/glob": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10052,16 +9882,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10074,8 +9900,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10085,8 +9909,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10097,16 +9919,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10116,8 +9934,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10130,16 +9946,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10152,16 +9964,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minipass": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10172,8 +9980,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minizlib": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10183,8 +9989,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10197,16 +10001,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ms": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/needle": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-      "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10224,8 +10024,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-      "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -10247,8 +10045,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10262,16 +10058,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10282,8 +10074,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10296,8 +10086,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10307,8 +10095,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10318,8 +10104,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10329,8 +10113,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10340,8 +10122,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10351,8 +10131,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10363,8 +10141,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10374,16 +10150,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
@@ -10399,16 +10171,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10424,8 +10192,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rimraf": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10438,32 +10204,24 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/semver": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10473,24 +10231,18 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10500,8 +10252,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10516,8 +10266,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10530,8 +10278,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -10541,8 +10287,6 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/tar": {
       "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10561,16 +10305,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -10580,16 +10320,12 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/yallist": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
@@ -16528,8 +16264,7 @@
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -17917,9 +17652,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -18110,10 +17845,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -18171,7 +17904,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -19980,9 +19712,9 @@
       }
     },
     "@janelia-flyem/neuroglancer": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@janelia-flyem/neuroglancer/-/neuroglancer-2.21.0.tgz",
-      "integrity": "sha512-LzNBHsODirgBzRSqd1fg0M3KE8el5zjaQYywmxI3g6lmk8KboNNufAaF31T63m3+TmSjb51s9RRmVNddbOEAfQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@janelia-flyem/neuroglancer/-/neuroglancer-2.24.0.tgz",
+      "integrity": "sha512-5nuFOqgjMzpt9bwibcXs1+5pVjR4sQGKeiIwQgxqaW8WV78HlwXyaxO7jsMit3AJf2lakooZyD0BKcsDUR268A==",
       "requires": {
         "@types/codemirror": "0.0.98",
         "@types/gl-matrix": "^2.4.5",
@@ -20025,16 +19757,16 @@
           "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw=="
         },
         "sockjs-client": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
-          "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.1.tgz",
+          "integrity": "sha512-VnVAb663fosipI/m6pqRXakEOw7nvd7TUgdr3PlR/8V2I95QIdwT8L4nMxhyU8SmDBHYXU1TOElaKOmKLfYzeQ==",
           "requires": {
             "debug": "^3.2.6",
             "eventsource": "^1.0.7",
             "faye-websocket": "^0.11.3",
             "inherits": "^2.0.4",
             "json3": "^3.3.3",
-            "url-parse": "^1.4.7"
+            "url-parse": "^1.5.1"
           }
         },
         "typescript": {
@@ -20045,11 +19777,11 @@
       }
     },
     "@janelia-flyem/react-neuroglancer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@janelia-flyem/react-neuroglancer/-/react-neuroglancer-2.0.3.tgz",
-      "integrity": "sha512-FrE5YpXqW2LdHdpjxo51zQmLPcK6sq3z2z7FBpjoQCIOOzrVYkeoPJIc4VolOTlc44IK+FMrsCei1bZlRBvIFA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@janelia-flyem/react-neuroglancer/-/react-neuroglancer-2.2.2.tgz",
+      "integrity": "sha512-m9Cw2pyc7C+F5SAMgYPubj+mnky7LL6O6wFoZfthQsJcntbO4S9tWYroiLIcx6czIvFO58HZFaGTVkRHSWztEw==",
       "requires": {
-        "@janelia-flyem/neuroglancer": "^2.21.0"
+        "@janelia-flyem/neuroglancer": "^2.24.0"
       }
     },
     "@jest/console": {
@@ -20545,9 +20277,9 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg=="
     },
     "@types/gl-matrix": {
       "version": "2.4.5",
@@ -22227,29 +21959,21 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "bundled": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "bundled": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22259,15 +21983,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "bundled": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22277,43 +21997,31 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "bundled": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "bundled": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "bundled": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "bundled": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "bundled": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22322,29 +22030,21 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "bundled": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "bundled": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "bundled": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22353,15 +22053,11 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "bundled": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22377,8 +22073,6 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22392,15 +22086,11 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "bundled": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22409,8 +22099,6 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22419,8 +22107,6 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22430,22 +22116,16 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "bundled": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "bundled": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22454,15 +22134,11 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "bundled": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22471,15 +22147,11 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "bundled": true,
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22489,8 +22161,6 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22499,8 +22169,6 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22509,15 +22177,11 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "bundled": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-              "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22528,8 +22192,6 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-              "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22547,8 +22209,6 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22558,15 +22218,11 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "bundled": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22576,8 +22232,6 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22589,22 +22243,16 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "bundled": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "bundled": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22613,22 +22261,16 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "bundled": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "bundled": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22638,22 +22280,16 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "bundled": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "bundled": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22665,8 +22301,6 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "bundled": true,
                   "optional": true
                 }
@@ -22674,8 +22308,6 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22690,8 +22322,6 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22700,50 +22330,36 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "bundled": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "bundled": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "bundled": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "bundled": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "bundled": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "bundled": true,
               "optional": true
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22752,8 +22368,6 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22764,8 +22378,6 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22774,15 +22386,11 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "bundled": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22797,15 +22405,11 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "bundled": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -22814,15 +22418,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "bundled": true,
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "bundled": true,
               "optional": true
             }
@@ -22964,9 +22564,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codemirror": {
-      "version": "5.59.4",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.4.tgz",
-      "integrity": "sha512-achw5JBgx8QPcACDDn+EUUXmCYzx/zxEtOGXyjvLEvYY8GleUrnfm5D+Zb+UjShHggXKDT9AXrbkBZX6a0YSQg=="
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.60.0.tgz",
+      "integrity": "sha512-AEL7LhFOlxPlCL8IdTcJDblJm8yrAGib7I+DErJPdZd4l6imx8IMgKK3RblVgBQqz3TZJR4oknQ03bz+uNjBYA=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -27153,29 +26753,21 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "bundled": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "bundled": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27185,15 +26777,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "bundled": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27203,43 +26791,31 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "bundled": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "bundled": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "bundled": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "bundled": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "bundled": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27248,29 +26824,21 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "bundled": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "bundled": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "bundled": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27279,15 +26847,11 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "bundled": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27303,8 +26867,6 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27318,15 +26880,11 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "bundled": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27335,8 +26893,6 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27345,8 +26901,6 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27356,22 +26910,16 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "bundled": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "bundled": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27380,15 +26928,11 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "bundled": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27397,15 +26941,11 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "bundled": true,
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27415,8 +26955,6 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27425,8 +26963,6 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27435,15 +26971,11 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "bundled": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-              "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27454,8 +26986,6 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-              "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27473,8 +27003,6 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27484,15 +27012,11 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "bundled": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27502,8 +27026,6 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27515,22 +27037,16 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "bundled": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "bundled": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27539,22 +27055,16 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "bundled": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "bundled": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27564,22 +27074,16 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "bundled": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "bundled": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27591,8 +27095,6 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "bundled": true,
                   "optional": true
                 }
@@ -27600,8 +27102,6 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27616,8 +27116,6 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27626,50 +27124,36 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "bundled": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "bundled": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "bundled": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "bundled": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "bundled": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "bundled": true,
               "optional": true
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27678,8 +27162,6 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27690,8 +27172,6 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27700,15 +27180,11 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "bundled": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27723,15 +27199,11 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "bundled": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -27740,15 +27212,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "bundled": true,
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "bundled": true,
               "optional": true
             }
@@ -33800,9 +33268,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.4.3",
-    "@janelia-flyem/react-neuroglancer": "^2.0.3",
+    "@janelia-flyem/react-neuroglancer": "^2.2.2",
     "@material-ui/core": "^4.9.10",
     "@material-ui/icons": "^4.0.0-beta.0",
     "@material-ui/lab": "^4.0.0-alpha.57",

--- a/src/Annotate.jsx
+++ b/src/Annotate.jsx
@@ -8,10 +8,13 @@ import PropTypes from 'prop-types';
 import { useSelector, shallowEqual } from 'react-redux';
 import { getNeuroglancerColor } from '@janelia-flyem/react-neuroglancer';
 import activeElementNeedsKeypress from './utils/events';
-import { makeLayersFromDataset } from './utils/neuroglancer';
+import {
+  makeLayersFromDataset,
+  hasMergeableLayer,
+} from './utils/neuroglancer';
 import AnnotationPanel from './Annotation/AnnotationPanel';
 import {
-  ANNOTATION_COLUMNS, ATLAS_COLUMNS, ANNOTATION_SHADER, ATLAS_SHADER,
+  ATLAS_COLUMNS, ANNOTATION_SHADER, ATLAS_SHADER, getAnnotationColumnSetting,
 } from './Annotation/AnnotationUtils';
 import NeuPrintManager from './Connections/NeuPrintManager';
 import ConnectionsPanel from './Connections/ConnectionsPanel';
@@ -245,7 +248,7 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
           name: 'annotations',
           tools: [pointTool, lineTool],
           dataConfig: {
-            columns: ANNOTATION_COLUMNS,
+            columns: getAnnotationColumnSetting(dataset),
             kind: 'Normal',
             allowingImport: true,
             allowingExport: true,
@@ -316,11 +319,15 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
           }}
         >
           <AnnotationPanel config={annotationConfig} actions={actions}>
-            <MergePanel
-              tabName="merges"
-              mergeManager={mergeManager.current}
-              addAlert={actions.addAlert}
-            />
+            {
+              hasMergeableLayer(dataset) ? (
+                <MergePanel
+                  tabName="merges"
+                  mergeManager={mergeManager.current}
+                  addAlert={actions.addAlert}
+                />
+              ) : null
+            }
             <ConnectionsPanel
               tabName="connections"
               neuPrintManager={neuPrintManager.current}

--- a/src/Annotate.jsx
+++ b/src/Annotate.jsx
@@ -101,19 +101,8 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
 
   useEffect(() => {
     if (dataset && user) {
-      let datasetUrl = dataset.location;
-      if (!dataset.location.match(/^dvid/)) {
-        datasetUrl = `precomputed://${dataset.location}`;
-      }
-
       const layers = [
-        {
-          name: dataset.name,
-          type: 'image',
-          source: {
-            url: datasetUrl,
-          },
-        },
+        ...makeLayersFromDataset(dataset, true),
         {
           name: 'annotations',
           type: 'annotation',
@@ -132,7 +121,6 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
           shader: ATLAS_SHADER,
           tool: 'annotatePoint',
         },
-        ...makeLayersFromDataset(dataset, true),
       ];
 
       const viewerOptions = {
@@ -151,7 +139,9 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
       // dimensions used. This should ideally be fixed in the initViewer action or
       // the dimensions should be passed as part of the dataset object from the clio
       // backend.
-      if (dataset.name === 'mb20') {
+      if (dataset.dimensions) {
+        viewerOptions.dimensions = dataset.dimensions;
+      } else if (dataset.name === 'mb20') {
         viewerOptions.dimensions = {
           x: [4e-9, 'm'],
           y: [4e-9, 'm'],

--- a/src/Annotation/AnnotationPanel.jsx
+++ b/src/Annotation/AnnotationPanel.jsx
@@ -30,6 +30,11 @@ export default function AnnotationPanel(props) {
   const classes = useStyles({ width: config.width });
   const [tabValue, setTabValue] = React.useState('0');
 
+  let validChildren = [];
+  if (children) {
+    validChildren = Array.isArray(children) ? children.filter((child) => child) : [children];
+  }
+
   const handleTabChange = (event, newValue) => {
     setTabValue(newValue);
     const index = parseInt(newValue, 10);
@@ -44,7 +49,7 @@ export default function AnnotationPanel(props) {
     setTabValue('0');
   }, [config.datasetName]);
 
-  const numTabs = config.layers.length + (children ? children.length : 0);
+  const numTabs = config.layers.length + validChildren.length;
   const totalWidth = config.width.replace(/\D/g, '');
   const tabWidth = Math.max(totalWidth / numTabs, 100);
   const tabStyle = { minWidth: `${tabWidth}px`, maxWidth: `${tabWidth}px` };
@@ -67,17 +72,13 @@ export default function AnnotationPanel(props) {
     </TabPanel>
   ));
 
-  if (children) {
-    let childArray = children;
-    if (!Array.isArray(childArray)) {
-      childArray = [children];
-    }
+  if (validChildren) {
     const startIndex = tabs.length;
-    tabs = tabs.concat(childArray.map((child, index) => (
+    tabs = tabs.concat(validChildren.map((child, index) => (
       <Tab label={child.props.tabName} key={child.props.tabName} value={`${startIndex + index}`} style={tabStyle} />
     )));
 
-    tabPanels = tabPanels.concat(childArray.map((child, index) => (
+    tabPanels = tabPanels.concat(validChildren.map((child, index) => (
       <TabPanel key={child.props.tabName} value={`${startIndex + index}`} className={classes.tabPanel}>
         {child}
       </TabPanel>

--- a/src/Annotation/DataTable/DataCellEdit.jsx
+++ b/src/Annotation/DataTable/DataCellEdit.jsx
@@ -2,9 +2,13 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 import Input from '@material-ui/core/Input';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
 
 export default function DataCellEdit(props) {
-  const { value, placeholder, onValueChange } = props;
+  const {
+    value, placeholder, onValueChange, config,
+  } = props;
   const [inputValue, setInputValue] = React.useState(value);
 
   const handleValueChange = (event) => {
@@ -12,19 +16,47 @@ export default function DataCellEdit(props) {
     onValueChange(event.target.value);
   };
 
-  return (
-    <Input
-      value={inputValue}
-      placeholder={placeholder}
-      onChange={handleValueChange}
-    />
-  );
+  let widget = <div>{value}</div>;
+  switch (config.type) {
+    case 'input':
+      widget = (
+        <Input
+          value={inputValue}
+          placeholder={placeholder}
+          onChange={handleValueChange}
+        />
+      );
+      break;
+    case 'select':
+      widget = (
+        <Select onChange={handleValueChange} value={inputValue}>
+          {
+            config.options.map((option) => (
+              <MenuItem
+                key={option.label}
+                value={option.value}
+              >
+                {option.label}
+              </MenuItem>
+            ))
+          }
+        </Select>
+      );
+      break;
+    default:
+      break;
+  }
+
+  return widget;
 }
 
 DataCellEdit.propTypes = {
   value: PropTypes.string.isRequired,
   onValueChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
+  config: PropTypes.shape({
+    type: PropTypes.string,
+  }).isRequired,
 };
 
 DataCellEdit.defaultProps = {

--- a/src/Annotation/DataTable/DataEdit.jsx
+++ b/src/Annotation/DataTable/DataEdit.jsx
@@ -48,6 +48,24 @@ export default function DataEdit(props) {
       return column.cell;
     }
 
+    if (column.editElement) {
+      return (
+        <DataCellEdit
+          config={column.editElement}
+          onValueChange={
+            (value) => {
+              setNewData({ ...newData, [column.field]: value });
+            }
+          }
+          value={data[column.field]}
+          placeholder={column.placeholder}
+        />
+      );
+    }
+
+    return data[column.field];
+
+    /*
     return (column.editElement && column.editElement.type === 'input') ? (
       <DataCellEdit
         config={column}
@@ -62,6 +80,7 @@ export default function DataEdit(props) {
         placeholder={column.placeholder}
       />
     ) : data[column.field];
+    */
   };
 
   return (

--- a/src/ImageSearch/NGLoader.jsx
+++ b/src/ImageSearch/NGLoader.jsx
@@ -22,19 +22,8 @@ export default function NGLoader({
 
   useEffect(() => {
     if (dataset) {
-      let datasetUrl = dataset.location;
-      if (!dataset.location.match(/^dvid/)) {
-        datasetUrl = `precomputed://${dataset.location}`;
-      }
-
       const layers = [
-        {
-          name: dataset.name,
-          type: 'image',
-          source: {
-            url: datasetUrl,
-          },
-        },
+        ...makeLayersFromDataset(dataset, false),
         {
           name: 'annotations',
           type: 'annotation',
@@ -42,7 +31,6 @@ export default function NGLoader({
             url: `clio://${projectUrl}/${dataset.name}?auth=neurohub`,
           },
         },
-        ...makeLayersFromDataset(dataset, false),
       ];
 
       const viewerOptions = {

--- a/src/utils/neuroglancer.js
+++ b/src/utils/neuroglancer.js
@@ -25,11 +25,13 @@ export function makeLayersFromDataset(dataset, inferringType) {
 
       const layerConfig = {
         name: layer.name,
-        type,
         source: {
           url: layerUrl,
         },
+        ...layer,
       };
+
+      layerConfig.type = type;
 
       if (type === 'segmentation') {
         layerConfig.source.subsources = {
@@ -43,4 +45,22 @@ export function makeLayersFromDataset(dataset, inferringType) {
   }
 
   return [];
+}
+
+export function isMergeableLayer(layer) {
+  if (layer && layer.roles) {
+    return layer.roles.includes('mergeable');
+  }
+
+  return false;
+}
+
+export function hasMergeableLayer(dataset) {
+  const { layers } = dataset;
+
+  if (layers) {
+    return layers.some((layer) => isMergeableLayer(layer));
+  }
+
+  return false;
 }


### PR DESCRIPTION
This PR has several updates related to update layer info in the server:
1. Hide the merge panel if no mergeable layer exists.
2. Show a type column in the annotation table if there is a mergeable layer
3. Include additional layer information from the server in neuroglancer state
4. Use grayscale layer info to create the image layer. The old way of using location to create a default image layer is also preserved for compatibility.

NOTE: this PR works the best with the latest neuroglancer update, which can handle the cosem dataset for annotations.