### PR TITLE
Fixes dimension order in viewer options

### DIFF
--- a/src/utils/neuroglancer.js
+++ b/src/utils/neuroglancer.js
@@ -81,12 +81,23 @@ export function getDatasetLocation(dataset) {
 }
 
 export function makeViewOptionsFromDataset(dataset, customOptions) {
+  let dimensions = {
+    x: [8e-9, 'm'],
+    y: [8e-9, 'm'],
+    z: [8e-9, 'm'],
+  };
+  if (dataset.dimensions) {
+    dimensions = {
+      // Make sure the order is in 'x', 'y', 'z'.
+      // A different order can cause incorrect coordinate transform in Neuroglancer.
+      x: dataset.dimensions.x,
+      y: dataset.dimensions.y,
+      z: dataset.dimensions.z,
+      ...dataset.dimensions,
+    };
+  }
   return {
-    dimensions: dataset.dimensions || {
-      x: [8e-9, 'm'],
-      y: [8e-9, 'm'],
-      z: [8e-9, 'm'],
-    },
+    dimensions,
     position: dataset.position || [],
     crossSectionScale: dataset.crossSectionScale || 2,
     projectionScale: dataset.projectionScale || 2600,


### PR DESCRIPTION
Neuroglancer needs the keys to be ordered as 'x', 'y', and 'z' in the dimensions object, while dimensions fetched from the database are not necessarily in this order. This PR fixes the problem.