### PR TITLE
Adds editing for body annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clioWeb",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clioWeb",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "dependencies": {
         "@babel/core": "7.4.3",
         "@janelia-flyem/react-neuroglancer": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clioWeb",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "private": true,
   "dependencies": {
     "@babel/core": "7.4.3",

--- a/src/Annotation/AnnotationRequest.js
+++ b/src/Annotation/AnnotationRequest.js
@@ -1,22 +1,69 @@
 /* eslint-disable-next-line  import/prefer-default-export */
-export function queryBodyAnnotations(projectUrl, token, dataset, query) {
-  const url = `${projectUrl}/json-annotations/${dataset.key}/neurons/query${dataset.tag ? `?version=${dataset.tag}` : ''}`;
-  const body = JSON.stringify(query);
-  const options = {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    body,
-  };
+function fetchJson(url, token, method, body) {
+  const options = { method };
+  if (token) {
+    options.headers = { Authorization: `Bearer ${token}` };
+  }
+  if (body) {
+    options.body = body;
+  }
 
   return fetch(url, options).then(
     (res) => {
       if (res.ok) {
         return res.json();
       }
-      const err = `Posting to ${url} failed: ${res.statusText}`;
+      const err = `${options.method} ${url} failed: ${res.statusText}`;
       throw new Error(err);
     },
   );
+}
+
+function getBodyAnnotationUrl(projectUrl, dataset, cmd) {
+  let url = `${projectUrl}/json-annotations/${dataset.key}/neurons`;
+  if (cmd) {
+    url += `/${cmd}`;
+  }
+  if (dataset.tag) {
+    url += `?version=${dataset.tag}`;
+  }
+  return url;
+}
+
+export function queryBodyAnnotations(projectUrl, token, dataset, query) {
+  const url = getBodyAnnotationUrl(projectUrl, dataset, 'query');
+  const body = JSON.stringify(query);
+  return fetchJson(url, token, 'POST', body);
+}
+
+export function getBodyAnnotation(projectUrl, token, dataset, bodyid) {
+  const url = getBodyAnnotationUrl(projectUrl, dataset, `id-number/${bodyid}`);
+  return fetchJson(url, token, 'GET').catch(() => (null));
+}
+
+export async function updateBodyAnnotation(
+  projectUrl, token, dataset, annotation, processNewAnnotation,
+) {
+  if (annotation && annotation.bodyid) {
+    const upload = (a) => {
+      const processed = { ...a };
+      Object.keys(alert).forEach((key) => {
+        if (key.startsWith('_')) {
+          delete processed[key];
+        }
+      });
+
+      return fetchJson(getBodyAnnotationUrl(projectUrl, dataset), token, 'POST', JSON.stringify(processed));
+    };
+
+    const data = await getBodyAnnotation(projectUrl, token, dataset, annotation.bodyid);
+    let newAnnotation = annotation;
+    if (data && data.bodyid) {
+      newAnnotation = { ...data, ...annotation };
+    }
+
+    return upload(newAnnotation).then(processNewAnnotation(newAnnotation));
+  }
+
+  return Promise.reject(new Error('The input annotation is invalid'));
 }

--- a/src/Annotation/BodyAnnotation.jsx
+++ b/src/Annotation/BodyAnnotation.jsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
 import {
   getMergeableLayerFromDataset,
   getLocateServiceUrl,
@@ -136,28 +135,12 @@ function BodyAnnotation({
 
   return (
     <div className={classes.annotationRoot}>
-      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-        <BodyAnnotationQuery
-          defaultQueryString={query ? JSON.stringify(query) : ''}
-          onQueryChanged={onQueryChanged}
-          loading={loading}
-        />
-        <Button
-          color="primary"
-          variant="contained"
-          disabled={loading}
-          onClick={
-            () => {
-              // onQueryChanged({ bodyid: mergeManager.selection });
-              onQueryChanged({ field: 'bodyid', op: 'in', value: mergeManager.selection });
-              // console.log(segmentationLayer && segmentationLayer.segments);
-              console.log(mergeManager.selection);
-            }
-          }
-        >
-          Selected Segments
-        </Button>
-      </div>
+      <BodyAnnotationQuery
+        defaultQueryString={query ? JSON.stringify(query) : ''}
+        onQueryChanged={onQueryChanged}
+        loading={loading}
+        getSelectedSegments={() => mergeManager.selection}
+      />
       <hr />
       <BodyAnnotationTable data={rows} dataConfig={config.dataConfig} />
     </div>

--- a/src/Annotation/BodyAnnotation.jsx
+++ b/src/Annotation/BodyAnnotation.jsx
@@ -12,6 +12,7 @@ import BodyAnnotationTable from './BodyAnnotationTable';
 import BodyAnnotationQuery from './BodyAnnotationQuery';
 import {
   queryBodyAnnotations,
+  updateBodyAnnotation,
 } from './AnnotationRequest';
 
 const useStyles = makeStyles(() => (
@@ -78,7 +79,19 @@ function BodyAnnotation({
     return {
       id: key,
       ...annotations[key],
-      // updateAction: () => { },
+      updateAction: (change) => {
+        if (Object.keys(change).length > 0) {
+          updateBodyAnnotation(projectUrl, token, dataset, {
+            ...change, bodyid: annotations[key].bodyid,
+          }, (newAnnotation) => {
+            setAnnotations({ ...annotations, [key]: newAnnotation });
+          }).catch((error) => {
+            const message = `Failed to update annotation for ${key}.`;
+            actions.addAlert({ severity: 'warning', message });
+            console.log(error);
+          });
+        }
+      },
       locateAction,
     };
   });
@@ -110,6 +123,8 @@ function BodyAnnotation({
             setLoading(false);
           },
         ).catch((error) => {
+          const message = 'Failed to query bodies.';
+          actions.addAlert({ severity: 'warning', message });
           console.log(error);
           setLoading(false);
         });

--- a/src/Annotation/BodyAnnotationQuery.jsx
+++ b/src/Annotation/BodyAnnotationQuery.jsx
@@ -8,9 +8,10 @@ const useStyles = makeStyles(() => (
   {
     controlRow: {
       display: 'flex',
-      flexFlow: 'row',
+      flexDirection: 'row',
       justifyContent: 'left',
       minHeight: '0px',
+      alignItems: 'center',
     },
   }
 ));
@@ -19,6 +20,7 @@ function BodyAnnotationQuery({
   defaultQueryString,
   onQueryChanged,
   loading,
+  getSelectedSegments,
 }) {
   const classes = useStyles();
   const [queryString, setQueryString] = useState(defaultQueryString);
@@ -38,8 +40,8 @@ function BodyAnnotationQuery({
     <div className={classes.controlRow}>
       <TextField
         label="Query"
-        defaultValue={queryString}
-        onKeyUp={(event) => {
+        value={queryString}
+        onChange={(event) => {
           setQueryString(event.target.value);
         }}
         multiline
@@ -53,6 +55,24 @@ function BodyAnnotationQuery({
       >
         {loading ? 'Loading...' : 'Submit'}
       </Button>
+      <Button
+        color="primary"
+        variant="contained"
+        disabled={loading}
+        style={{ height: 'fit-content' }}
+        onClick={
+          () => {
+            const segments = getSelectedSegments();
+            const query = { field: 'bodyid', op: 'in', value: segments };
+            setQueryString(JSON.stringify(query));
+            if (segments.length > 0) {
+              onQueryChanged(query);
+            }
+          }
+        }
+      >
+        Selected Segments
+      </Button>
     </div>
   );
 }
@@ -61,6 +81,7 @@ BodyAnnotationQuery.propTypes = {
   defaultQueryString: PropTypes.string.isRequired,
   onQueryChanged: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
+  getSelectedSegments: PropTypes.func.isRequired,
 };
 
 export default BodyAnnotationQuery;

--- a/src/Annotation/DataTable/DataCellEdit.jsx
+++ b/src/Annotation/DataTable/DataCellEdit.jsx
@@ -51,7 +51,7 @@ export default function DataCellEdit(props) {
 }
 
 DataCellEdit.propTypes = {
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   onValueChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
   config: PropTypes.shape({
@@ -60,5 +60,6 @@ DataCellEdit.propTypes = {
 };
 
 DataCellEdit.defaultProps = {
+  value: '',
   placeholder: '',
 };

--- a/src/Annotation/DataTable/DataEdit.jsx
+++ b/src/Annotation/DataTable/DataEdit.jsx
@@ -16,7 +16,7 @@ export default function DataEdit(props) {
 
   const dataForEditing = {};
   config.columns.forEach((column) => {
-    if (column.editElement) {
+    if (column.editElement && data[column.field] !== undefined) {
       dataForEditing[column.field] = data[column.field];
     }
   });


### PR DESCRIPTION
This PR allows the user to edit a body annotation in the table. It also has an update on the behavior of the 'selected segments' button. When the button is clicked, the query box will be updated to show the query of finding selected bodies so that the user can conveniently adds or removes a body.