### PR TITLE
Several fixes for the body annotation table

### DIFF
--- a/src/Annotate.jsx
+++ b/src/Annotate.jsx
@@ -94,7 +94,7 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
   const projectUrl = useSelector((state) => state.clio.get('projectUrl'), shallowEqual);
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_WIDTH_PX);
   const classes = useStyles({ sidebarWidth });
-  const [bodyAnnotatinQuery, setBodyAnnotationQuery] = useState(null);
+  const [bodyAnnotatinQuery, setBodyAnnotationQuery] = useState({});
 
   const roles = useSelector((state) => state.user.get('roles'), shallowEqual);
   let { groups } = roles;
@@ -321,10 +321,13 @@ export default function Annotate({ children, actions, datasets, selectedDatasetN
                   dataset={dataset}
                   projectUrl={projectUrl}
                   token={user ? user.getAuthResponse().id_token : ''}
-                  query={bodyAnnotatinQuery}
+                  query={bodyAnnotatinQuery[dataset.name]}
                   onQueryChanged={(query) => {
                     actions.syncViewer();
-                    setBodyAnnotationQuery(query);
+                    setBodyAnnotationQuery((prevState) => ({
+                      ...prevState,
+                      [dataset.name]: query,
+                    }));
                   }}
                   actions={actions}
                   mergeManager={mergeManager.current}

--- a/src/Annotation/AnnotationRequest.js
+++ b/src/Annotation/AnnotationRequest.js
@@ -54,7 +54,11 @@ export function getBodyAnnotation(projectUrl, token, dataset, bodyid) {
 
 export async function queryBodyAnnotations(projectUrl, token, dataset, query) {
   if (Object.keys(query).length === 1 && query.bodyid) {
-    return getBodyAnnotations(projectUrl, token, dataset, query.bodyid);
+    let { bodyid } = query;
+    if (typeof bodyid === 'number') {
+      bodyid = [bodyid];
+    }
+    return getBodyAnnotations(projectUrl, token, dataset, bodyid);
   }
 
   const url = getBodyAnnotationUrl(projectUrl, dataset, 'query');

--- a/src/Annotation/AnnotationUtils.js
+++ b/src/Annotation/AnnotationUtils.js
@@ -162,6 +162,10 @@ export function getAnnotationIcon(kind, action, selected) {
 export function getBodyAnnotationColumnSetting(dataset) {
   if (dataset) {
     // FIXME: Temporary schema handling
+    if (dataset.bodyAnnotationSchema) {
+      return dataset.bodyAnnotationSchema;
+    }
+
     if (dataset.name === 'hemibrain') {
       return {
         shape: ['bodyid', 'type', 'instance', 'cell_body_fiber', 'comment'],

--- a/src/Annotation/BodyAnnotation.jsx
+++ b/src/Annotation/BodyAnnotation.jsx
@@ -69,10 +69,11 @@ function BodyAnnotation({
 
   const rows = annotations.map((annotation) => {
     let locateAction = null;
-    const { point, bodyid } = annotation;
-    if (point) {
+    const { position, point, bodyid } = annotation;
+    const predefinedPosition = position || point;
+    if (predefinedPosition) {
       locateAction = () => {
-        actions.setViewerCameraPosition(point);
+        actions.setViewerCameraPosition(predefinedPosition);
       };
     } else if (locateServiceUrl) {
       locateAction = () => {

--- a/src/Annotation/DataTable/DataTableUtils.js
+++ b/src/Annotation/DataTable/DataTableUtils.js
@@ -50,7 +50,7 @@ export function getSortedFieldArray(columns) {
       field: key,
       title: collection[key].title,
       rank: collection[key].rank,
-    })).sort((c1, c2) => compareField(c1.field, c2.field));
+    })).sort((c1, c2) => compareField(collection)(c1.field, c2.field));
   }
 
   return columns;


### PR DESCRIPTION
This PR includes:
1. fixing query with single body ID
2. fixing locating a body with its predefined position
3. using body annotation schema from the server
4. separating queries for different datasets