### PR TITLE
Improve annotation UI

### DIFF
--- a/src/Annotation/AnnotationRequest.js
+++ b/src/Annotation/AnnotationRequest.js
@@ -27,6 +27,15 @@ function getBodyAnnotationUrl(projectUrl, dataset, cmd) {
   return url;
 }
 
+function fillBodyAnnotations(annotations, bodies) {
+  ((typeof bodies === 'number') ? [bodies] : bodies).forEach((bodyid) => {
+    if (annotations.findIndex((a) => (a.bodyid === bodyid)) < 0) {
+      annotations.push({ bodyid });
+    }
+  });
+  return annotations.filter((a) => a.bodyid);
+}
+
 export async function getBodyAnnotations(projectUrl, token, dataset, bodies) {
   if (bodies && bodies.length > 0) {
     const url = getBodyAnnotationUrl(projectUrl, dataset, `id-number/${bodies.join(',')}`);
@@ -35,12 +44,7 @@ export async function getBodyAnnotations(projectUrl, token, dataset, bodies) {
       if (!Array.isArray(annotations)) {
         annotations = [annotations];
       }
-      bodies.forEach((bodyid) => {
-        if (annotations.findIndex((a) => (a.bodyid === bodyid)) < 0) {
-          annotations.push({ bodyid });
-        }
-      });
-      return annotations.filter((a) => a.bodyid);
+      return fillBodyAnnotations(annotations, bodies);
     }
   }
 
@@ -65,7 +69,11 @@ export async function queryBodyAnnotations(projectUrl, token, dataset, query) {
   const body = JSON.stringify(query);
   const response = await fetchJson(url, token, 'POST', body);
   if (response) {
-    return Object.values(response);
+    const annotations = Object.values(response);
+    if (Object.keys(query).length === 1 && query.bodyid) {
+      return fillBodyAnnotations(annotations, query.bodyid);
+    }
+    return annotations;
   }
 
   return [];

--- a/src/Annotation/AnnotationTable.jsx
+++ b/src/Annotation/AnnotationTable.jsx
@@ -19,6 +19,7 @@ import Box from '@material-ui/core/Box';
 import {
   getSortedFieldArray,
   sortColumns,
+  useStyles,
 } from './DataTable/DataTableUtils';
 import DataFieldControl from './DataTable/DataFieldControl';
 import DataTable from './DataTable/DataTable';
@@ -39,21 +40,11 @@ import ImportAnnotation from './ImportAnnotation';
 import ExportAnnotation from './ExportAnnotation';
 import debounce from '../utils/debounce';
 import { getLayerFromState } from '../utils/state';
-// import { useLocalStorage } from '../utils/hooks';
-// import BodyAnnotationTable from './BodyAnnotationTable';
 
 const DEBUG = false;
 
-/*
-function getLayerFromState(state, layerName) {
-  const layers = state.viewer.getIn(['ngState', 'layers']);
-  const layer = layers.find((e) => (e.name === layerName));
-
-  return layer;
-}
-*/
-
 function AnnotationTable(props) {
+  const classes = useStyles();
   const {
     layerName,
     dataConfig,
@@ -261,7 +252,7 @@ function AnnotationTable(props) {
 
   const makeTableHeaderRow = React.useCallback((dataHeaders, filteredRows) => (
     <TableRow>
-      <TableCell padding="none">
+      <TableCell padding="none" className={classes.toolColumn}>
         <Box display="flex" flexDirection="row">
           {dataConfig.allowingImport ? (
             <ImportAnnotation
@@ -281,7 +272,7 @@ function AnnotationTable(props) {
       {dataHeaders}
       <TableCell />
     </TableRow>
-  ), [dataConfig, uploadAnnotations, getAnnotations, actions.addAlert]);
+  ), [dataConfig, uploadAnnotations, getAnnotations, actions.addAlert, classes]);
 
   const { groups } = dataSource;
   const groupSelection = groups && groups.length > 0

--- a/src/Annotation/AnnotationTable.jsx
+++ b/src/Annotation/AnnotationTable.jsx
@@ -257,7 +257,7 @@ function AnnotationTable(props) {
     });
   }, [layerName, actions]);
 
-  const getLocateIcon = React.useCallback((row, selected) => (getAnnotationIcon(row.kind, 'locate', selected)), []);
+  const getLocateIcon = React.useCallback((row, selected) => (getAnnotationIcon(row.kind, 'locate', selected, row.checked)), []);
 
   const makeTableHeaderRow = React.useCallback((dataHeaders, filteredRows) => (
     <TableRow>

--- a/src/Annotation/BodyAnnotationQuery.jsx
+++ b/src/Annotation/BodyAnnotationQuery.jsx
@@ -46,6 +46,7 @@ function BodyAnnotationQuery({
         }}
         multiline
         rows={3}
+        style={{ width: '50%' }}
         variant="outlined"
       />
       <Button

--- a/src/Annotation/BodyAnnotationTable.jsx
+++ b/src/Annotation/BodyAnnotationTable.jsx
@@ -21,6 +21,7 @@ function BodyAnnotationTable({ data, dataConfig }) {
           shape: value,
         }));
       }}
+      fieldHint
     />
   ) : null;
 

--- a/src/Annotation/DataTable/DataCellEdit.jsx
+++ b/src/Annotation/DataTable/DataCellEdit.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Input from '@material-ui/core/Input';
 import Select from '@material-ui/core/Select';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 
 export default function DataCellEdit(props) {
@@ -14,6 +16,11 @@ export default function DataCellEdit(props) {
   const handleValueChange = (event) => {
     setInputValue(event.target.value);
     onValueChange(event.target.value);
+  };
+
+  const handleChecked = (event) => {
+    setInputValue(event.target.checked);
+    onValueChange(event.target.checked);
   };
 
   let widget = <div>{value}</div>;
@@ -43,6 +50,15 @@ export default function DataCellEdit(props) {
         </Select>
       );
       break;
+    case 'boolean':
+      widget = (
+        <FormControlLabel
+          control={
+            <Checkbox onChange={handleChecked} checked={inputValue} />
+          }
+        />
+      );
+      break;
     default:
       break;
   }
@@ -51,7 +67,7 @@ export default function DataCellEdit(props) {
 }
 
 DataCellEdit.propTypes = {
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onValueChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
   config: PropTypes.shape({

--- a/src/Annotation/DataTable/DataEdit.jsx
+++ b/src/Annotation/DataTable/DataEdit.jsx
@@ -5,7 +5,7 @@ import IconButton from '@material-ui/core/IconButton';
 import DoneIcon from '@material-ui/icons/DoneAllTwoTone';
 import RevertIcon from '@material-ui/icons/NotInterestedOutlined';
 import { TableCell } from '@material-ui/core';
-import Box from '@material-ui/core/Box';
+// import Box from '@material-ui/core/Box';
 
 import DataCellEdit from './DataCellEdit';
 
@@ -48,65 +48,54 @@ export default function DataEdit(props) {
       return column.cell;
     }
 
+    if (column.field === '#toolColumn') {
+      const children = [
+        <IconButton
+          key="DataEdit.Done"
+          aria-label="ok"
+          disabled={!isNewDataValid() || !hasChanged()}
+          onClick={() => takeChange(newData)}
+        >
+          <DoneIcon />
+        </IconButton>,
+        <IconButton
+          key="DataEdit.Cancel"
+          aria-label="cancel"
+          onClick={cancelEdit}
+        >
+          <RevertIcon />
+        </IconButton>,
+      ];
+      return column.makeCell(children);
+    }
+
     if (column.editElement) {
       return (
-        <DataCellEdit
-          config={column.editElement}
-          onValueChange={
-            (value) => {
-              setNewData({ ...newData, [column.field]: value });
+        <TableCell key={column.field}>
+          <DataCellEdit
+            config={column.editElement}
+            onValueChange={
+              (value) => {
+                setNewData({ ...newData, [column.field]: value });
+              }
             }
-          }
-          value={data[column.field]}
-          placeholder={column.placeholder}
-        />
+            value={data[column.field]}
+            placeholder={column.placeholder}
+          />
+        </TableCell>
       );
     }
 
-    return data[column.field];
-
-    /*
-    return (column.editElement && column.editElement.type === 'input') ? (
-      <DataCellEdit
-        config={column}
-        onValueChange={
-          (value) => {
-            const changed = { ...newData };
-            changed[column.field] = value;
-            setNewData(changed);
-          }
-        }
-        value={data[column.field]}
-        placeholder={column.placeholder}
-      />
-    ) : data[column.field];
-    */
+    return (
+      <TableCell key={column.field}>
+        {data[column.field]}
+      </TableCell>
+    );
   };
 
   return (
     <TableRow>
-      {config.columns.map((column) => (
-        <TableCell key={column.field}>
-          {columnToCell(column)}
-        </TableCell>
-      ))}
-      <TableCell>
-        <Box display="flex" flexDirection="row">
-          <IconButton
-            aria-label="ok"
-            disabled={!isNewDataValid() || !hasChanged()}
-            onClick={() => takeChange(newData)}
-          >
-            <DoneIcon />
-          </IconButton>
-          <IconButton
-            aria-label="cancel"
-            onClick={cancelEdit}
-          >
-            <RevertIcon />
-          </IconButton>
-        </Box>
-      </TableCell>
+      {config.columns.map((column) => columnToCell(column))}
     </TableRow>
   );
 }

--- a/src/Annotation/DataTable/DataFieldControl.jsx
+++ b/src/Annotation/DataTable/DataFieldControl.jsx
@@ -8,7 +8,9 @@ import FormControl from '@material-ui/core/FormControl';
 import Input from '@material-ui/core/Input';
 import Checkbox from '@material-ui/core/Checkbox';
 
-function DataFieldControl({ fields, selectedFields, onChange }) {
+function DataFieldControl({
+  fields, selectedFields, onChange, fieldHint,
+}) {
   const handleChange = (event) => {
     onChange(event.target.value);
   };
@@ -33,7 +35,7 @@ function DataFieldControl({ fields, selectedFields, onChange }) {
           {fields.map((field) => (
             <MenuItem key={field.field} value={field.field}>
               <Checkbox checked={selectedFields.includes(field.field)} />
-              {field.title}
+              {`${field.title}${fieldHint ? ` (${field.field})` : ''}`}
             </MenuItem>
           ))}
         </Select>
@@ -49,6 +51,11 @@ DataFieldControl.propTypes = {
   })).isRequired,
   selectedFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   onChange: PropTypes.func.isRequired,
+  fieldHint: PropTypes.bool,
+};
+
+DataFieldControl.defaultProps = {
+  fieldHint: false,
 };
 
 export default DataFieldControl;

--- a/src/Annotation/DataTable/DataTable.jsx
+++ b/src/Annotation/DataTable/DataTable.jsx
@@ -63,11 +63,15 @@ export default function DataTable({
         (row) => Object.keys(filter).every(
           (key) => {
             if (filter[key]) {
+              let rowValue = row[key];
               const filterString = filter[key].toLowerCase();
-              if (typeof row[key] === 'boolean') {
-                return row[key] ? (filterString === 'y') : (filterString === 'n');
+              if (typeof rowValue === 'boolean') {
+                return rowValue ? (filterString === 'y') : (filterString === 'n');
               }
-              return (row[key] && row[key].toLowerCase().includes(filterString));
+              if (typeof rowValue === 'number') {
+                rowValue = rowValue.toString();
+              }
+              return (rowValue && rowValue.toLowerCase().includes(filterString));
             }
             return true;
           },

--- a/src/Annotation/DataTable/DataTable.jsx
+++ b/src/Annotation/DataTable/DataTable.jsx
@@ -61,7 +61,16 @@ export default function DataTable({
     if (filter) {
       const newRows = data.rows.filter(
         (row) => Object.keys(filter).every(
-          (key) => (!filter[key]) || (row[key] && row[key].includes(filter[key])),
+          (key) => {
+            if (filter[key]) {
+              const filterString = filter[key].toLowerCase();
+              if (typeof row[key] === 'boolean') {
+                return row[key] ? (filterString === 'y') : (filterString === 'n');
+              }
+              return (row[key] && row[key].toLowerCase().includes(filterString));
+            }
+            return true;
+          },
         ),
       );
       setFilteredRows(newRows);

--- a/src/Annotation/DataTable/DataTableHead.jsx
+++ b/src/Annotation/DataTable/DataTableHead.jsx
@@ -7,11 +7,13 @@ import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
 import {
   getVisibleColumns,
+  useStyles,
 } from './DataTableUtils';
 
 export default function DataTableHead({
   columns, makeRow, handleFilterChange,
 }) {
+  const classes = useStyles();
   const handleFilterKeyUp = (event, column) => {
     handleFilterChange(column, event.target.value);
   };
@@ -40,9 +42,8 @@ export default function DataTableHead({
   } else {
     headers = (
       <TableRow>
-        <TableCell />
+        <TableCell className={classes.toolColumn} />
         {filterRow}
-        <TableCell />
       </TableRow>
     );
   }

--- a/src/Annotation/DataTable/DataTableRow.jsx
+++ b/src/Annotation/DataTable/DataTableRow.jsx
@@ -16,9 +16,11 @@ import {
   getColumnSetting,
   getColumnFields,
   COLUMNS_PROP_TYPES,
+  useStyles,
 } from './DataTableUtils';
 
 function DataTableRow(props) {
+  const classes = useStyles();
   const {
     columns, row, selected, getLocateIcon,
   } = props;
@@ -83,11 +85,24 @@ function DataTableRow(props) {
   if (editing) {
     return (
       <DataEdit
-        config={
-          {
-            columns: [{ cell: locateButton, field: '#locateButton' }, ...visibleColumns],
-          }
-        }
+        config={{
+          columns: [
+            {
+              field: '#toolColumn',
+              makeCell: function ToolColumn(children) {
+                return (
+                  <TableCell className={classes.toolColumn}>
+                    <Box display="flex" flexDirection="row">
+                      {locateButton}
+                      {children}
+                    </Box>
+                  </TableCell>
+                );
+              },
+            },
+            ...visibleColumns,
+          ],
+        }}
         data={row}
         cancelEdit={cancelEdit}
         takeChange={takeChange}
@@ -137,8 +152,15 @@ function DataTableRow(props) {
 
   return (
     <TableRow>
-      <TableCell>
-        {row.locateAction ? locateButton : undefined}
+      <TableCell
+        padding="none"
+        className={classes.toolColumn}
+      >
+        <Box display="flex" flexDirection="row">
+          {row.locateAction ? locateButton : undefined}
+          {row.updateAction ? editButton : undefined}
+          {row.deleteAction ? deleteButton : undefined}
+        </Box>
       </TableCell>
       {visibleColumns.map((column) => (
         <TableCell
@@ -151,12 +173,6 @@ function DataTableRow(props) {
           {getCellElement(column)}
         </TableCell>
       ))}
-      <TableCell padding="none">
-        <Box display="flex" flexDirection="row">
-          {row.updateAction ? editButton : undefined}
-          {row.deleteAction ? deleteButton : undefined}
-        </Box>
-      </TableCell>
     </TableRow>
   );
 }

--- a/src/Annotation/DataTable/DataTableRow.jsx
+++ b/src/Annotation/DataTable/DataTableRow.jsx
@@ -128,6 +128,10 @@ function DataTableRow(props) {
       }
     }
 
+    if (typeof value === 'boolean') {
+      return value ? 'Y' : 'N';
+    }
+
     return value;
   };
 

--- a/src/Annotation/DataTable/DataTableUtils.js
+++ b/src/Annotation/DataTable/DataTableUtils.js
@@ -1,4 +1,17 @@
 import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles(() => (
+  {
+    toolColumn: {
+      position: 'sticky',
+      backgroundColor: '#fcfcfc',
+      opacity: 0.9,
+      left: 0,
+      zIndex: 3,
+    },
+  }
+));
 
 export const COLUMNS_PROP_TYPES = PropTypes.oneOfType([
   PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
The data table now supports boolean fields, enabling a 'check' field for point annotations. The tool icons in a table are moved to the first column, which has its position fixed during scrolling.