### PR TITLE
Enables sorting in data tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clioWeb",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clioWeb",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@babel/core": "7.4.3",
         "@janelia-flyem/react-neuroglancer": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clioWeb",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "dependencies": {
     "@babel/core": "7.4.3",

--- a/src/Annotation/BodyAnnotationQuery.jsx
+++ b/src/Annotation/BodyAnnotationQuery.jsx
@@ -1,20 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
-
-const useStyles = makeStyles(() => (
-  {
-    controlRow: {
-      display: 'flex',
-      flexDirection: 'row',
-      justifyContent: 'left',
-      minHeight: '0px',
-      alignItems: 'center',
-    },
-  }
-));
+import { useStyles } from './DataTable/DataTableUtils';
 
 function BodyAnnotationQuery({
   defaultQueryString,

--- a/src/Annotation/DataTable/DataTableHead.jsx
+++ b/src/Annotation/DataTable/DataTableHead.jsx
@@ -5,34 +5,50 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
+import TableSortLabel from '@material-ui/core/TableSortLabel';
 import {
   getVisibleColumns,
   useStyles,
 } from './DataTableUtils';
 
 export default function DataTableHead({
-  columns, makeRow, handleFilterChange,
+  columns, makeRow, handleFilterChange, order, orderBy, onRequestSort,
 }) {
   const classes = useStyles();
-  const handleFilterKeyUp = (event, column) => {
-    handleFilterChange(column, event.target.value);
+  const createSortHandler = (field) => (event) => {
+    onRequestSort(event, field);
+  };
+  const createFilterHandler = (field) => (event) => {
+    handleFilterChange(field, event.target.value);
   };
 
   const visibleColumns = getVisibleColumns(columns);
 
   const filterRow = visibleColumns.map((column) => (
-    <TableCell key={column.field}>
-      <TextField
-        label={column.title}
-        onKeyUp={(event) => handleFilterKeyUp(event, column.field)}
-        disabled={!column.filterEnabled}
-        style={{
-          whiteSpace: 'nowrap',
-        }}
-        InputProps={{
-          style: { width: `${column.title.length * 8}px` },
-        }}
-      />
+    <TableCell
+      key={column.field}
+      sortDirection={orderBy === column.field ? order : false}
+    >
+      <div className={classes.controlRow}>
+        <TextField
+          label={column.title}
+          onKeyUp={createFilterHandler(column.field)}
+          disabled={!column.filterEnabled}
+          style={{
+            whiteSpace: 'nowrap',
+          }}
+          InputProps={{
+            style: { width: `${column.title.length * 7}px` },
+          }}
+        />
+        <TableSortLabel
+          active={orderBy === column.field}
+          direction={(orderBy === column.field) ? order : 'asc'}
+          onClick={createSortHandler(column.field)}
+        >
+          <font style={{ color: 'lightgray' }}>●</font>
+        </TableSortLabel>
+      </div>
     </TableCell>
   ));
 
@@ -69,8 +85,13 @@ DataTableHead.propTypes = {
   ]).isRequired,
   handleFilterChange: PropTypes.func.isRequired, // Function of filtering a given column
   makeRow: PropTypes.func,
+  order: PropTypes.string,
+  orderBy: PropTypes.string,
+  onRequestSort: PropTypes.func.isRequired,
 };
 
 DataTableHead.defaultProps = {
   makeRow: null,
+  order: false,
+  orderBy: null,
 };

--- a/src/Annotation/DataTable/DataTableUtils.js
+++ b/src/Annotation/DataTable/DataTableUtils.js
@@ -10,6 +10,13 @@ export const useStyles = makeStyles(() => (
       left: 0,
       zIndex: 3,
     },
+    controlRow: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'left',
+      minHeight: '0px',
+      alignItems: 'center',
+    },
   }
 ));
 


### PR DESCRIPTION
This PR adds a function to allow the user to sort columns in an annotation table.
It also fixes the text color in neuroglancer UI.
**NOTE**: Please update it together with the latest `feature-flyem-newbuild` branch of neuroglancer, which includes a fix on panel dragging from the master branch.