### PR TITLE
Allows viewing bodies listed in the body annotation table

### DIFF
--- a/src/Annotation/AnnotationTable.jsx
+++ b/src/Annotation/AnnotationTable.jsx
@@ -300,13 +300,13 @@ function AnnotationTable(props) {
     );
   }
 
-  const tableControls = (
+  const makeTableControl = React.useCallback(() => (
     <div style={{ display: 'flex', flexFlow: 'row' }}>
       {groupSelection}
       <div style={{ height: '100%', width: '10px' }} />
       {fieldSelection}
     </div>
-  );
+  ), [groupSelection, fieldSelection]);
 
   return (
     <div>
@@ -317,7 +317,7 @@ function AnnotationTable(props) {
         getId={React.useCallback((row) => row.id, [])}
         getLocateIcon={getLocateIcon}
         makeHeaderRow={makeTableHeaderRow}
-        tableControls={tableControls}
+        makeTableControl={makeTableControl}
       />
       <hr />
       {tools ? (

--- a/src/Annotation/BodyAnnotation.jsx
+++ b/src/Annotation/BodyAnnotation.jsx
@@ -121,6 +121,10 @@ function BodyAnnotation({
     }
   }, [dataset, projectUrl, token, query, actions]);
 
+  const showBodies = React.useCallback((ids) => {
+    actions.setViewerSegments(ids);
+  }, [actions]);
+
   return (
     <div className={classes.annotationRoot}>
       <BodyAnnotationQuery
@@ -130,7 +134,11 @@ function BodyAnnotation({
         getSelectedSegments={() => mergeManager.selection}
       />
       <hr />
-      <BodyAnnotationTable data={rows} dataConfig={config.dataConfig} />
+      <BodyAnnotationTable
+        data={rows}
+        dataConfig={config.dataConfig}
+        showBodies={showBodies}
+      />
     </div>
   );
 }

--- a/src/Annotation/BodyAnnotationTable.jsx
+++ b/src/Annotation/BodyAnnotationTable.jsx
@@ -1,36 +1,64 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import Button from '@material-ui/core/Button';
 import DataTable from './DataTable/DataTable';
 import DataFieldControl from './DataTable/DataFieldControl';
 import {
   getSortedFieldArray,
   sortColumns,
+  useStyles,
 } from './DataTable/DataTableUtils';
 // import { useLocalStorage } from '../utils/hooks';
 
-function BodyAnnotationTable({ data, dataConfig }) {
+function BodyAnnotationTable({ data, dataConfig, showBodies }) {
   const [columns, setColumns] = useState(dataConfig.columns);
+  const classes = useStyles();
 
-  const fieldSelection = dataConfig.columns.shape ? (
-    <DataFieldControl
-      fields={getSortedFieldArray(columns)}
-      selectedFields={columns.shape}
-      onChange={(value) => {
-        setColumns(sortColumns({
-          ...columns,
-          shape: value,
-        }));
-      }}
-      fieldHint
-    />
-  ) : null;
+  const makeTableControl = React.useCallback(({ filteredRows }) => {
+    const fieldControl = columns.shape ? (
+      <DataFieldControl
+        fields={getSortedFieldArray(columns)}
+        selectedFields={columns.shape}
+        onChange={(value) => {
+          setColumns(sortColumns({
+            ...columns,
+            shape: value,
+          }));
+        }}
+        fieldHint
+      />
+    ) : null;
+
+    const showBodyButton = showBodies ? (
+      <Button
+        color="primary"
+        variant="contained"
+        onClick={
+          () => showBodies(filteredRows.map((row) => row.bodyid))
+        }
+      >
+        View Bodies
+      </Button>
+    ) : null;
+
+    if (!fieldControl && !showBodyButton) {
+      return null;
+    }
+
+    return (
+      <div className={classes.controlRow}>
+        {fieldControl}
+        {showBodyButton}
+      </div>
+    );
+  }, [columns, classes, showBodies]);
 
   return (
     <DataTable
       data={{ rows: data }}
       config={{ ...dataConfig, columns }}
       getId={React.useCallback((row) => row.bodyid, [])}
-      tableControls={fieldSelection}
+      makeTableControl={makeTableControl}
     />
   );
 }
@@ -38,6 +66,11 @@ function BodyAnnotationTable({ data, dataConfig }) {
 BodyAnnotationTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   dataConfig: PropTypes.object.isRequired,
+  showBodies: PropTypes.func,
+};
+
+BodyAnnotationTable.defaultProps = {
+  showBodies: null,
 };
 
 export default BodyAnnotationTable;

--- a/src/Annotation/DataTable/DataTable.jsx
+++ b/src/Annotation/DataTable/DataTable.jsx
@@ -58,7 +58,7 @@ const useStyles = makeStyles({
 });
 
 export default function DataTable({
-  data, config, selectedId, getId, getLocateIcon, makeHeaderRow, tableControls,
+  data, config, selectedId, getId, getLocateIcon, makeHeaderRow, makeTableControl,
 }) {
   const classes = useStyles();
   const rowsPerPageOptions = [5, 10, 20, { label: 'All', value: -1 }];
@@ -167,7 +167,7 @@ export default function DataTable({
 
   return (
     <div className={classes.dataTableRoot}>
-      {tableControls}
+      {makeTableControl ? makeTableControl({ filteredRows }) : null}
       <TableContainer className={classes.container}>
         <Table stickyHeader className={classes.table} size="small" aria-label="simple table">
           <DataTableHead
@@ -217,12 +217,12 @@ DataTable.propTypes = {
   selectedId: PropTypes.string, // Selected ID
   getLocateIcon: PropTypes.func,
   makeHeaderRow: PropTypes.func,
-  tableControls: PropTypes.object,
+  makeTableControl: PropTypes.func,
 };
 
 DataTable.defaultProps = {
   selectedId: null,
   getLocateIcon: null,
   makeHeaderRow: null,
-  tableControls: null,
+  makeTableControl: null,
 };

--- a/src/WorkSpaces.jsx
+++ b/src/WorkSpaces.jsx
@@ -85,7 +85,7 @@ function WorkSpaces(props) {
         datasets={datasets}
         selectedDatasetName={selectedDatasetName}
       >
-        <NeuroGlancer viewerState={viewerState.get('ngState')} brainMapsClientId="NOT_A_VALID_ID" />
+        <NeuroGlancer viewerState={viewerState.get('ngState')} brainMapsClientId="NOT_A_VALID_ID" ngServer=" https://clio-ng.janelia.org" />
       </RenderedComponent>
     </Suspense>
   );


### PR DESCRIPTION
This PR adds a button to allow the user to view bodies listed in the annotation panel by selecting them in the viewer. Please update it together with react-neuroglancer and neuroglancer updates.