### PR TITLE
Change the default projectionOrientation

### DIFF
--- a/src/utils/neuroglancer.js
+++ b/src/utils/neuroglancer.js
@@ -126,12 +126,7 @@ export function makeViewOptionsFromDataset(dataset, customOptions) {
     position: predefined.position || dataset.position || [],
     crossSectionScale: predefined.crossSectionScale || null,
     projectionScale: predefined.projectionScale || null,
-    projectionOrientation: predefined.projectionOrientation || [
-      -0.2363949418067932,
-      -0.28796303272247314,
-      0.011459439061582088,
-      0.927935004234314,
-    ],
+    projectionOrientation: predefined.projectionOrientation || [0.0, 0.0, 0.0, 1.0],
     crossSectionOrientation: predefined.crossSectionOrientation || null,
     layout: '4panel',
     ...customOptions,


### PR DESCRIPTION
Change the default `projectionOrientation` to the same one neuroglancer itself uses.