### PR TITLE
Do not add `last_modified_by` field to body annotations anymore.

### DIFF
--- a/src/Annotation/AnnotationRequest.js
+++ b/src/Annotation/AnnotationRequest.js
@@ -131,7 +131,7 @@ export async function updateBodyAnnotation(
     };
 
     const data = await getBodyAnnotation(projectUrl, token, dataset, annotation.bodyid);
-    let newAnnotation = { ...annotation, last_modified_by: user };
+    let newAnnotation = { ...annotation };
 
     if (data && data.bodyid) {
       newAnnotation = { ...data, ...newAnnotation };


### PR DESCRIPTION
As requested by Stuart, do not add `last_modified_by` field to body annotations anymore.

I searched the source and found only this line that included that text. I'm not  a JS programmer, and I'm not set up to build/test this, so it's over to you.