### PR TITLE
fix: Improves site resilience when neuroglancer state is misconfigured.

### DIFF
--- a/src/Annotation/BodyAnnotation/index.jsx
+++ b/src/Annotation/BodyAnnotation/index.jsx
@@ -47,7 +47,11 @@ function BodyAnnotation({
   let locateServiceUrl = null;
   if (mergeableLayer) {
     const url = mergeableLayer.location || mergeableLayer.source.url || mergeableLayer.source;
-    locateServiceUrl = getLocateServiceUrl(url, config.user);
+    if (url) {
+      locateServiceUrl = getLocateServiceUrl(url, config.user);
+    } else {
+      console.warn('No location found for mergeable layer', mergeableLayer);
+    }
   }
 
   const updateAnnotations = (oldAnnotations, newAnnotation) => {


### PR DESCRIPTION
Adds a check to make sure that urls are present in the mergable layer, before
testing against them.
@krokicki